### PR TITLE
XO shouldn't be a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,9 @@
     "cheerio": "^0.19.0",
     "got": "^4.1.1",
     "native-or-bluebird": "^1.2.0",
-    "underscore": "^1.8.3",
-    "xo": "^0.5.0"
+    "underscore": "^1.8.3"
   },
   "devDependencies": {
-    "eslint": "^1.0.0",
-    "eslint-config-xo": "^0.1.0",
     "expect.js": "^0.3.1",
     "mocha": "^2.2.5",
     "mocha-clean": "^0.4.0",


### PR DESCRIPTION
Also removed `eslint` and `eslint-config-xo` as you don't need them when using `xo` directly.
